### PR TITLE
Fix bugs causing ETL to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,9 +291,13 @@ cd application/dummy_uploads
 zip -r uploads.zip .
 ```
 
-2. Then, upload the ZIP to the `dev-raw` bucket at the `dogs/landing` prefix.
-3. This should then trigger an s3 bucket notification to run the lambda:
+2. Then, upload the ZIP to the `dev-raw` bucket at the `dogs/landing/` prefix:
 
+```sh
+aws s3 rm s3://dev-demo-raw/dogs/landing/uploads.zip
+aws s3 cp ./application/dummy_uploads/uploads.zip s3://dev-demo-raw/dogs/landing/
+```
+3. This should then trigger an s3 bucket notification to run the lambda.
 4. This lambda, in turn, should unzip the files and re-upload them into the `dev-processed` bucket,
 at the `dogs/daily` root with prefix determined by date. i.e. for 20241008.csv we'd expect
 an upload at `dogs/daily/_year=2024/_month=10/_day=08/viewings`

--- a/application/unzip-lambda/unzip_lambda/lambda_function.py
+++ b/application/unzip-lambda/unzip_lambda/lambda_function.py
@@ -26,11 +26,10 @@ import io
 # Third-party modules
 import boto3
 
-LOGGER: logging.Logger = logging.get_logger(__name__)
+LOGGER: logging.Logger = logging.getLogger(__name__)
 ERROR_SNS_TOPIC: str = os.environ['ERROR_SNS_TOPIC']
 TARGET_PREFIX: str = "dogs/daily"
 TARGET_BUCKET_NAME: str = os.environ['TARGET_BUCKET_NAME']
-SOURCE_PREFIX: str = "dogs/landing"
 
 logging_level: str = os.environ.get("LOG_LEVEL")
 LOGGER.setLevel(logging_level if logging_level is not None else "INFO")
@@ -91,9 +90,9 @@ def get_date_partition(file_key) -> (str, str, str):
     LOGGER.info(f"get_date_partition for file_key = {file_key}")
     head, file_name = ntpath.split(file_key)
 
-    year = file_name[0, 4]
-    month = file_name[4, 6]
-    day = file_name[6, 8]
+    year = file_name[0:4]
+    month = file_name[4:6]
+    day = file_name[6:8]
 
     LOGGER.info(f"year = {year}, month = {month}, day = {day}")
 
@@ -140,14 +139,17 @@ def unzip_file(source_bucket: str,
         try:
             s3_client.upload_fileobj(
                 zip_buffer.open(filename),
-                bucket=destination_bucket,
+                Bucket=destination_bucket,
                 Key=destination_path
             )
             LOGGER.info(f"Successfully unzipped {filename}")
         except Exception as e:
             failed = True
             LOGGER.error(f"Failed to unzip {filename}")
-            raise RuntimeError("Unable to unzip {filename}")
+            LOGGER.error(e)
+            raise RuntimeError(f"Unable to unzip {filename}")
+        finally:
+            counter += 1
 
     return not failed
 

--- a/infrastructure/modules/lambda/data.tf
+++ b/infrastructure/modules/lambda/data.tf
@@ -2,11 +2,11 @@ locals {
   known_buckets = {
     raw : {
       name : lower("${var.environment}-${var.application_name}-raw")
-      arn : lower("arn:aws:s3:::fom-${var.environment}-${var.application_name}-raw")
+      arn : lower("arn:aws:s3:::${var.environment}-${var.application_name}-raw")
     },
     processed : {
       name : lower("${var.environment}-${var.application_name}-processed")
-      arn : lower("arn:aws:s3:::fom-${var.environment}-${var.application_name}-processed")
+      arn : lower("arn:aws:s3:::${var.environment}-${var.application_name}-processed")
     }
   }
   known_kms_keys = {

--- a/infrastructure/modules/lambda/locals.tf
+++ b/infrastructure/modules/lambda/locals.tf
@@ -53,10 +53,10 @@ locals {
       source_folder : "application/unzip-lambda/unzip_lambda"
       handler : "lambda_function.lambda_handler"
       environment_variables : {
-        ERROR_SNS_TOPIC = data.aws_sns_topic.known_topics["etl-failure"].arn,
-        TARGET_PREFIX   = "dogs/daily",
-        TARGET_BUCKET   = local.known_buckets.processed.name,
-        LOG_LEVEL       = "INFO"
+        ERROR_SNS_TOPIC    = data.aws_sns_topic.known_topics["etl-failure"].arn,
+        TARGET_PREFIX      = "dogs/daily",
+        TARGET_BUCKET_NAME = local.known_buckets.processed.name,
+        LOG_LEVEL          = "INFO"
       }
       iam_policy_statements : [
         {

--- a/infrastructure/modules/s3_bucket/locals.tf
+++ b/infrastructure/modules/s3_bucket/locals.tf
@@ -34,7 +34,7 @@ locals {
       versioning : true,
       enable_kms : true,
       prefixes = [
-        "dogs/landing"
+        "dogs/landing/"
       ]
     },
     {
@@ -43,7 +43,7 @@ locals {
       versioning : true,
       enable_kms : true,
       prefixes = [
-        "dogs/daily"
+        "dogs/daily/"
       ]
     },
     {

--- a/infrastructure/modules/s3_bucket_notifications/data.tf
+++ b/infrastructure/modules/s3_bucket_notifications/data.tf
@@ -2,7 +2,7 @@ locals {
   known_buckets = {
     raw : {
       name : lower("${var.environment}-${var.application_name}-raw")
-      arn : lower("arn:aws:s3:::fom-${var.environment}-${var.application_name}-raw")
+      arn : lower("arn:aws:s3:::${var.environment}-${var.application_name}-raw")
     },
   }
   known_lambdas = {


### PR DESCRIPTION
# Description

This PR includes bugs, and their fixes, encountered when actually running the process live. Namely:

- Incorrect indexing and method naming in Python
- Missing env vars in lambda deployment
- Incorrect known bucket names
-  Missing trailing `\` for bucket prefixes, causing them to be treated as files rather than intended folders

Updated README, where appropriate, with commands to initiate ETL.

Fixes #17 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Deployed locally.
- [x] After deploying, confirmed ETL process worked as intended. i.e:

![image](https://github.com/user-attachments/assets/6a6588bc-1fb9-4fb9-a49e-6e4d28f9fd91)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] Terraform validate works locally
- [x] Terraform plan passes in the pipeline with an expected result
- [x] Terraform plan does not show any unsuspected terraform destroy operations
